### PR TITLE
Fix read directory and read file HTTP 416 range error for Jianguoyun.com WebDAV server

### DIFF
--- a/app/scripts/webdav_client.js
+++ b/app/scripts/webdav_client.js
@@ -464,7 +464,7 @@
         for (var i = 0; i < split.length; i++) {
             result.push(encodeURIComponent(split[i]));
         }
-        return "/" + result.join("/");
+        return (path.charAt(0) == '/' ? "" : "/") + result.join("/");
     };
 
     // Export

--- a/app/scripts/webdav_fs.js
+++ b/app/scripts/webdav_fs.js
@@ -127,10 +127,21 @@
         console.log(options);
         var filePath = getOpenedFiles.call(this, options.fileSystemId)[options.openRequestId];
         var webDavClient = getWebDavClient.call(this, options.fileSystemId);
+        var cache = metadataCache.get(filePath);
+        var read_len = options.length;
+        if (cache.directoryExists && cache.fileExists) {
+            if (options.offset + options.length > cache.metadata.size) {
+                read_len = cache.metadata.size - options.offset;
+                if (read_len <= 0) {
+                    successCallback(new ArrayBuffer(0), false);
+                    return;
+                }
+            }
+        }
         webDavClient.readFile({
             path: filePath,
             offset: options.offset,
-            length: options.length,
+            length: read_len,
             onSuccess: function(result) {
                 console.log(result);
                 successCallback(result.data, result.hasMore);


### PR DESCRIPTION
A quick fix for this issue:
[https://github.com/yoichiro/chromeos-filesystem-webdav/issues/14](https://github.com/yoichiro/chromeos-filesystem-webdav/issues/14)

encodePath returns url after mounting WebDAV:
http://dav.jianguoyun.com//child-directory

WebDAV server returns 400 error for this kind of url.

Also Jianguoyun's WebDAV server returns HTTP 416 range error if read file range larger than file size,
while Chrome OS File app read file by 512KB range, normally we will always get 416 error on this kind of WebDAV server.
